### PR TITLE
テーブル削除と変換処理の最適化

### DIFF
--- a/Analog_Clock_System_BetaV1/ACS_OSC_Clock.py
+++ b/Analog_Clock_System_BetaV1/ACS_OSC_Clock.py
@@ -38,71 +38,6 @@ print("set_ip: ", ip, "\nset_port: ", port, "\n")
 
 print('Ctrl+Cで終了できます\n')
 
-#浮動小数点数演算はなんか知らないけどうまくいかないので良い方法思いつくまでゴリ押す
-NUMBER = {
-    00:0.00,
-    1:0.01,
-    2:0.02,
-    3:0.03,
-    4:0.04,
-    5:0.05,
-    6:0.06,
-    7:0.07,
-    8:0.08,
-    9:0.09,
-    10:0.10,
-    11:0.11,
-    12:0.12,
-    13:0.13,
-    14:0.14,
-    15:0.15,
-    16:0.16,
-    17:0.17,
-    18:0.18,
-    19:0.19,
-    20:0.20,
-    21:0.21,
-    22:0.22,
-    23:0.23,
-    24:0.24,
-    25:0.25,
-    26:0.26,
-    27:0.27,
-    28:0.28,
-    29:0.29,
-    30:0.30,
-    31:0.31,
-    32:0.32,
-    33:0.33,
-    34:0.34,
-    35:0.35,
-    36:0.36,
-    37:0.37,
-    38:0.38,
-    39:0.39,
-    40:0.40,
-    41:0.41,
-    42:0.42,
-    43:0.43,
-    44:0.44,
-    45:0.45,
-    46:0.46,
-    47:0.47,
-    48:0.48,
-    49:0.49,
-    50:0.50,
-    51:0.51,
-    52:0.52,
-    53:0.53,
-    54:0.54,
-    55:0.55,
-    56:0.56,
-    57:0.57,
-    58:0.58,
-    59:0.59,
-    60:0.60
-}
-
 NUMBER_HOURS = {
     0:0.0,
     1:0.01,
@@ -138,20 +73,20 @@ try:
         #PCのローカル時間を取得
         dt_now = datetime.datetime.now()
 
-        hours = dt_now.strftime('%H')
-        minutes = dt_now.strftime('%M')
-        seconds = dt_now.strftime('%S')
+        hours = dt_now.hour
+        minutes = dt_now.minute
+        seconds = dt_now.second
 
-        hours_hand = NUMBER_HOURS[int(hours)]
-        minutes_hand = NUMBER[int(minutes)]
-        seconds_hand = NUMBER[int(seconds)]
+        hours_hand = NUMBER_HOURS[hours]
+        minutes_hand = minutes / 100
+        seconds_hand = seconds / 100
 
         print("\r現在時刻:", hours,":",minutes,":",seconds, end="")
 
         #とんでけーー！！
-        client.send_message("/avatar/parameters/AC_hh", float(hours_hand))
-        client.send_message("/avatar/parameters/AC_mh", float(minutes_hand))
-        client.send_message("/avatar/parameters/AC_sc", float(seconds_hand))
+        client.send_message("/avatar/parameters/AC_hh", hours_hand)
+        client.send_message("/avatar/parameters/AC_mh", minutes_hand)
+        client.send_message("/avatar/parameters/AC_sc", seconds_hand)
 
         time.sleep(1)
 


### PR DESCRIPTION
時・分・秒を文字列から変換していたのでそれを削除して直接使用するようにしました。
あと、分・秒で変換テーブルを使っていたので計算で削除しました。

環境がないので全テストはできないですが、数値自体は同じ数値になることを確認したので
ご確認よろしくお願いします。
